### PR TITLE
docs: completa documentación con banners y firma

### DIFF
--- a/COMMANDS.md
+++ b/COMMANDS.md
@@ -1,4 +1,5 @@
-# Manual de Comandos – Yega MCP (CLI)
+# Manual de Comandos – Yega MCP (CLI) 🛠️
+![CLI Badge](https://img.shields.io/badge/CLI-Referencias-4caf50?style=for-the-badge&logo=gnu-bash&logoColor=white)
 
 Este manual resume los comandos del wrapper `chispart_mcp.sh` y la interfaz de chat para operar el orquestador y agentes usando lenguaje natural (Blackbox).
 
@@ -134,3 +135,7 @@ Comandos rápidos dentro del chat:
 - No subas `.env` al repositorio (ya está ignorado en `.gitignore`).
 - Usa `.env.example` con placeholders, no keys reales.
 - Evita imprimir keys en consola/logs.
+
+---
+**Sebastian Vernis | Soluciones Digitales**
+

--- a/README.md
+++ b/README.md
@@ -1,3 +1,43 @@
-# MCP-Chispart
+# MCP-Chispart 🚀
 
-Readme.md faltante 
+![Banner](https://img.shields.io/badge/MCP--Chispart-Agentes%20en%20acci%C3%B3n-1e88e5?style=for-the-badge)
+[![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)](LICENSE) [![Estado Beta](https://img.shields.io/badge/Estado-Beta-orange.svg)]() [![Hecho con ❤️](https://img.shields.io/badge/Hecho%20con-%E2%9D%A4-red.svg)]()
+
+## 📝 Descripción
+
+MCP-Chispart es un entorno de ejemplo para coordinar agentes MCP mediante un orquestador y adaptadores sencillos. Permite crear tareas, enrutar eventos y experimentar con proveedores externos como Blackbox o Codestral.
+
+## 🚀 Características
+
+- Orquestador en `scripts/chispart-mcp/orchestrator.mjs` con persistencia de tareas.
+- Wrapper `chispart_mcp.sh` para inicializar el entorno y ejecutar comandos.
+- Adaptadores de ejemplo: coordinator, qa, blackbox y mistral.
+- Estado persistente en `.mcp/state` y mailboxes en `.mcp/mailboxes`.
+
+## 📦 Instalación
+
+1. Clona el repositorio.
+2. Copia `.env.example` a `.env` y coloca tus claves.
+3. Ejecuta `./chispart_mcp.sh init` para preparar mailboxes y estado.
+
+## 📚 Uso
+
+Consulta el [Manual de Comandos](COMMANDS.md) para ver todos los comandos disponibles. Un flujo mínimo sería:
+
+```bash
+./chispart_mcp.sh agents
+./chispart_mcp.sh task "Investigar error de login" Yega-API
+./chispart_mcp.sh pump
+```
+
+## 🤝 Contribuciones
+
+¡Las contribuciones son bienvenidas! Abre un issue o un pull request con tus propuestas.
+
+## 📄 Licencia
+
+Este proyecto se distribuye bajo la licencia [MIT](LICENSE).
+
+---
+**Sebastian Vernis | Soluciones Digitales**
+


### PR DESCRIPTION
## Resumen
- agrega README con descripción, instalación y uso en español
- mejora manual de comandos con badge CLI y firma

## Testing
- `bash -n chispart_mcp.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b196a214f0832896ff41e7f2084f2c